### PR TITLE
feat: support for simple case

### DIFF
--- a/packages/prompt/README.md
+++ b/packages/prompt/README.md
@@ -23,6 +23,38 @@ pip install republic-prompt
 
 ## Quick Start
 
+### Option 1: Simple Template Formatting (90% of users)
+
+Just need to format template strings? Use the `format()` function - no setup required!
+
+```python
+from republic_prompt import format
+
+# Basic variable substitution
+result = format("Hello {{ name }}!", name="Alice")
+print(result)  # "Hello Alice!"
+
+# With custom functions
+def upper(text):
+    return text.upper()
+
+result = format(
+    "Hello {{ upper(name) }}!", 
+    custom_functions={"upper": upper},
+    name="Bob"
+)
+print(result)  # "Hello BOB!"
+
+# With conditional logic
+result = format(
+    "{% if count > 1 %}{{ count }} items{% else %}1 item{% endif %}",
+    count=3
+)
+print(result)  # "3 items"
+```
+
+### Option 2: Full Workspace (for complex projects)
+
 Forget about complex setup. Use `quick_render` to render templates from anywhere in just one line of code.
 
 ```python

--- a/packages/prompt/src/republic_prompt/__init__.py
+++ b/packages/prompt/src/republic_prompt/__init__.py
@@ -13,14 +13,28 @@ Usage:
         "./workspace",
         custom_functions={"my_func": lambda x: x.upper()}
     )
-    
+
     # Advanced customization
     from republic_prompt.loaders import function_loaders
     function_loaders.register("rust", RustFunctionLoader())
+
+    # Simple template string formatting (for users who don't need workspace)
+    from republic_prompt import format
+    result = format("Hello {{ name }}!", name="Alice")
 """
 
 from .workspace import PromptWorkspace, load_workspace, quick_render
 from .models import PromptModel, SnippetModel, TemplateModel
+from .simple import format, format_with_functions
 
 __version__ = "0.1.0"
-__all__ = ["PromptWorkspace", "PromptModel", "SnippetModel", "TemplateModel", "load_workspace", "quick_render"] 
+__all__ = [
+    "PromptWorkspace",
+    "PromptModel",
+    "SnippetModel",
+    "TemplateModel",
+    "load_workspace",
+    "quick_render",
+    "format",
+    "format_with_functions",
+]

--- a/packages/prompt/src/republic_prompt/simple.py
+++ b/packages/prompt/src/republic_prompt/simple.py
@@ -1,0 +1,105 @@
+"""Simple template formatting for Republic Prompt.
+
+This module provides a lightweight API for users who just need to format
+template strings without the full workspace functionality.
+"""
+
+from typing import Dict, Optional, Callable
+
+from .renderer import DefaultRenderer
+from .models import FunctionModel
+from .exceptions import TemplateError
+
+
+def format(
+    template: str,
+    custom_functions: Optional[Dict[str, Callable]] = None,
+    auto_escape: bool = False,
+    **variables,
+) -> str:
+    """Format a template string with variables.
+
+    This is a simple, lightweight function for users who just need to format
+    template strings without setting up a full workspace.
+
+    Args:
+        template: Template string using Jinja2 syntax (e.g., "Hello {{ name }}!")
+        custom_functions: Optional dict of custom functions to make available
+        auto_escape: Whether to auto-escape HTML content
+        **variables: Variables to substitute in the template
+
+    Returns:
+        Formatted string
+
+    Examples:
+        # Basic usage
+        result = format("Hello {{ name }}!", name="Alice")
+        # Returns: "Hello Alice!"
+
+        # With custom functions
+        def upper(text):
+            return text.upper()
+
+        result = format(
+            "Hello {{ upper(name) }}!",
+            custom_functions={"upper": upper},
+            name="Alice"
+        )
+        # Returns: "Hello ALICE!"
+
+        # With conditional logic
+        result = format(
+            "{% if count > 1 %}{{ count }} items{% else %}1 item{% endif %}",
+            count=3
+        )
+        # Returns: "3 items"
+    """
+    try:
+        # Create a minimal renderer with no snippets
+        renderer = DefaultRenderer(snippets={}, functions={}, auto_escape=auto_escape)
+
+        # Add custom functions if provided
+        if custom_functions:
+            for name, func in custom_functions.items():
+                renderer.add_function(
+                    name,
+                    FunctionModel(
+                        name=name,
+                        callable=func,
+                        signature=str(func.__name__)
+                        if hasattr(func, "__name__")
+                        else None,
+                        docstring=func.__doc__ if hasattr(func, "__doc__") else None,
+                    ),
+                )
+
+        # Render the template
+        return renderer.render_text(template, variables)
+
+    except Exception as e:
+        raise TemplateError(f"Failed to format template: {e}")
+
+
+def format_with_functions(
+    template: str,
+    functions: Dict[str, Callable],
+    auto_escape: bool = False,
+    **variables,
+) -> str:
+    """Format a template string with functions (alternative API).
+
+    This is an alternative to the main format() function that makes the
+    functions parameter more explicit.
+
+    Args:
+        template: Template string using Jinja2 syntax
+        functions: Dict of custom functions to make available
+        auto_escape: Whether to auto-escape HTML content
+        **variables: Variables to substitute in the template
+
+    Returns:
+        Formatted string
+    """
+    return format(
+        template, custom_functions=functions, auto_escape=auto_escape, **variables
+    )

--- a/packages/prompt/tests/test_simple_format.py
+++ b/packages/prompt/tests/test_simple_format.py
@@ -1,0 +1,130 @@
+"""Tests for simple template formatting functionality."""
+
+import pytest
+
+from republic_prompt import format, format_with_functions
+
+
+class TestSimpleFormat:
+    """Test the simple format function."""
+
+    def test_basic_variable_substitution(self):
+        """Test basic variable substitution."""
+        result = format("Hello {{ name }}!", name="Alice")
+        assert result == "Hello Alice!"
+
+    def test_multiple_variables(self):
+        """Test multiple variable substitution."""
+        result = format(
+            "Hello {{ name }} from {{ city }}!", name="Bob", city="New York"
+        )
+        assert result == "Hello Bob from New York!"
+
+    def test_with_custom_functions(self):
+        """Test custom function integration."""
+
+        def upper(text):
+            return text.upper()
+
+        def add_exclamation(text):
+            return text + "!"
+
+        result = format(
+            "{{ upper(name) }} {{ add_exclamation(greeting) }}",
+            custom_functions={"upper": upper, "add_exclamation": add_exclamation},
+            name="alice",
+            greeting="hello",
+        )
+        assert result == "ALICE hello!"
+
+    def test_conditional_logic(self):
+        """Test conditional logic in templates."""
+        result = format(
+            "{% if count > 1 %}{{ count }} items{% else %}1 item{% endif %}", count=3
+        )
+        assert result == "3 items"
+
+        result = format(
+            "{% if count > 1 %}{{ count }} items{% else %}1 item{% endif %}", count=1
+        )
+        assert result == "1 item"
+
+    def test_loops(self):
+        """Test loop functionality."""
+        result = format(
+            "{% for item in items %}{{ item }}{% if not loop.last %}, {% endif %}{% endfor %}",
+            items=["apple", "banana", "cherry"],
+        )
+        assert result == "apple, banana, cherry"
+
+    def test_format_with_functions_alias(self):
+        """Test the format_with_functions alias."""
+
+        def upper(text):
+            return text.upper()
+
+        result = format_with_functions(
+            "Hello {{ upper(name) }}!", functions={"upper": upper}, name="alice"
+        )
+        assert result == "Hello ALICE!"
+
+    def test_auto_escape(self):
+        """Test auto-escape functionality."""
+        result = format(
+            "{{ content }}", auto_escape=True, content="<script>alert('xss')</script>"
+        )
+        # Should escape HTML
+        assert "&lt;" in result and "&gt;" in result
+
+    def test_no_auto_escape(self):
+        """Test without auto-escape."""
+        result = format(
+            "{{ content }}", auto_escape=False, content="<script>alert('xss')</script>"
+        )
+        # Should not escape HTML
+        assert result == "<script>alert('xss')</script>"
+
+    def test_complex_template(self):
+        """Test a complex template with multiple features."""
+
+        def calculate_total(items):
+            return sum(item.get("price", 0) for item in items)
+
+        result = format(
+            """Order for {{ customer }}:
+{% for item in items %}
+- {{ item.name }}: ${{ "%.2f"|format(item.price) }}
+{% endfor %}
+Total: ${{ "%.2f"|format(calculate_total(items)) }}""",
+            custom_functions={"calculate_total": calculate_total},
+            customer="John",
+            items=[
+                {"name": "Laptop", "price": 999.99},
+                {"name": "Mouse", "price": 29.99},
+            ],
+        )
+
+        assert "Order for John:" in result
+        assert "Laptop: $999.99" in result
+        assert "Mouse: $29.99" in result
+        assert "Total: $1029.98" in result
+
+    def test_error_handling(self):
+        """Test error handling for invalid templates."""
+        # Test undefined variable - Jinja2 will render empty string by default
+        result = format("{{ undefined_variable }}")
+        assert result == ""
+
+        # Test calling undefined function - this should raise an exception
+        with pytest.raises(Exception):
+            format("{{ undefined_function() }}")
+
+    def test_empty_template(self):
+        """Test empty template."""
+        result = format("")
+        assert result == ""
+
+    def test_template_with_no_variables(self):
+        """Test template with no variables."""
+        result = format("Hello, world!")
+        assert result == "Hello, world!"

--- a/uv.lock
+++ b/uv.lock
@@ -489,7 +489,7 @@ test = [{ name = "pytest", specifier = ">=8.3.4" }]
 
 [[package]]
 name = "republic-prompt"
-version = "0.4.0"
+version = "0.1.0"
 source = { editable = "packages/prompt" }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
Just need to format template strings? Use the `format()` function - no setup required!

```python
from republic_prompt import format

# Basic variable substitution
result = format("Hello {{ name }}!", name="Alice")
print(result)  # "Hello Alice!"

# With custom functions
def upper(text):
    return text.upper()

result = format(
    "Hello {{ upper(name) }}!", 
    custom_functions={"upper": upper},
    name="Bob"
)
print(result)  # "Hello BOB!"

# With conditional logic
result = format(
    "{% if count > 1 %}{{ count }} items{% else %}1 item{% endif %}",
    count=3
)
print(result)  # "3 items"
```