### PR TITLE
fix(codex): preserve streamed text when completed response has empty output

### DIFF
--- a/src/republic/clients/openai_codex.py
+++ b/src/republic/clients/openai_codex.py
@@ -118,8 +118,19 @@ class OpenAICodexProvider(BaseOpenAIProvider):
         tool_calls: dict[str, dict[str, Any]],
         usage: dict[str, Any] | Any | None,
     ) -> Response:
+        # The Codex backend sometimes returns a completed SDK Response with output=[],
+        # even though earlier stream events (output_text.delta etc.) carried the full text.
+        # Only fall through to reconstruction when ALL of these hold:
+        #   1. status == "completed" (non-completed responses are returned as-is to preserve error info)
+        #   2. output is empty
+        #   3. the stream actually collected text or tool_calls
         if isinstance(completed_response, Response):
-            return completed_response
+            if completed_response.output:
+                return completed_response
+            if completed_response.status != "completed":
+                return completed_response
+            if not text and not tool_calls:
+                return completed_response
 
         payload: dict[str, Any] = {
             "id": getattr(completed_response, "id", None) or "resp_codex",

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -276,6 +276,37 @@ def make_responses_completed(usage: dict[str, Any] | None = None) -> Any:
     return SimpleNamespace(type="response.completed", response=response)
 
 
+def make_responses_completed_with_empty_output(
+    usage: dict[str, Any] | None = None,
+    *,
+    model: str = "gpt-5-codex",
+) -> Any:
+    """Simulate a Codex backend response.completed event with an SDK Response whose output is empty."""
+    full_usage: dict[str, Any] = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "total_tokens": 0,
+        "input_tokens_details": {"cached_tokens": 0},
+        "output_tokens_details": {"reasoning_tokens": 0},
+    }
+    if usage:
+        full_usage.update(usage)
+    payload: dict[str, Any] = {
+        "id": "resp_empty",
+        "created_at": 0,
+        "model": model,
+        "object": "response",
+        "status": "completed",
+        "output": [],
+        "parallel_tool_calls": False,
+        "tool_choice": "auto",
+        "tools": [],
+        "usage": full_usage,
+    }
+    response = Response.model_validate(payload)
+    return SimpleNamespace(type="response.completed", response=response)
+
+
 def make_responses_output_item_added(
     *,
     item_id: str = "fc_1",

--- a/tests/test_openai_codex_transport.py
+++ b/tests/test_openai_codex_transport.py
@@ -13,6 +13,7 @@ from republic.auth.openai_codex import extract_openai_codex_account_id
 
 from .fakes import (
     make_responses_completed,
+    make_responses_completed_with_empty_output,
     make_responses_function_done,
     make_responses_text_delta,
 )
@@ -264,3 +265,25 @@ def test_regular_openai_key_still_uses_anyllm(monkeypatch) -> None:
     assert llm.chat("Say hello") == "ok"
     assert created[0][0] == "openai"
     assert created[0][1]["api_key"] == "sk-test"
+
+
+def test_codex_completed_response_with_empty_output_preserves_streamed_text(monkeypatch) -> None:
+    """The Codex backend may return a completed SDK Response with output=[].
+
+    Streamed text collected from earlier events should be preserved instead of
+    returning the empty Response as-is.
+    Regression test: https://github.com/bubbuild/bub/issues/108
+    """
+    llm, _, _ = _build_codex_llm(
+        monkeypatch,
+        _async_items(
+            make_responses_text_delta("hello "),
+            make_responses_text_delta("world"),
+            make_responses_completed_with_empty_output(
+                {"input_tokens": 10, "output_tokens": 8, "total_tokens": 18},
+            ),
+        ),
+    )
+
+    result = llm.chat("say hi")
+    assert result == "hello world"


### PR DESCRIPTION
## Summary

Fix `empty response` failures on the Codex OAuth Responses path.

The Codex backend sometimes returns a `response.completed` event carrying an SDK `Response` object with `status="completed"` but `output=[]`, even though earlier stream events (`output_text.delta`) already delivered the full assistant text. `_build_response` unconditionally returned this empty `Response`, discarding the collected text and triggering a misleading `empty response` retry loop.

Related:
- https://github.com/bubbuild/bub/issues/101
- https://github.com/bubbuild/bub/issues/108

## Root cause

In `OpenAICodexProvider._build_response`:

```python
if isinstance(completed_response, Response):
    return completed_response  # unconditional — discards streamed text
```

The early return did not check whether `output` was actually populated. When `output=[]`, the already-collected `text` from stream events was never used to reconstruct the response.

## Changes

Narrow the early-return guard in `_build_response` so reconstruction from streamed data only happens under precise conditions:

1. **`output` is non-empty** → return as-is (output is good)
2. **`status != "completed"`** → return as-is (preserve error/incomplete metadata)
3. **stream collected nothing** → return as-is (avoid pointless reconstruction)

Only when all three checks fail (completed + empty output + stream has content) does the method fall through to the existing reconstruction logic via `_build_response_output`.

## Test plan

- [x] Added regression test: `response.completed` with a real SDK `Response(output=[])` while stream collected text — verifies text is preserved
- [x] All 127 existing tests pass unchanged